### PR TITLE
Only import _variables.scss since it contains everything we need.

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'mozfet:autoform-materialize',
   summary: 'Materialize theme for Autoform',
-  version: '3.5.2',
+  version: '3.5.3',
   git: 'https://github.com/mozfet/meteor-autoform-materialize.git'
 });
 

--- a/style.scss
+++ b/style.scss
@@ -1,4 +1,4 @@
-@import "{}/node_modules/materialize-css/sass/materialize.scss";
+@import "{}/node_modules/materialize-css/sass/components/_variables.scss";
 
 @media #{$small-and-down} {
 


### PR DESCRIPTION
This will prevent loading materialize twice in some setups, without any downsides.